### PR TITLE
Java 11: update plugin-pom and use api plugins where available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.26</version>
+		<version>4.52</version>
 		<relativePath />
 	</parent>
 
@@ -32,12 +32,10 @@
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/CodeBeamer+Source+Code+Coverage+Publisher+Plugin</url>
 
 	<properties>
-		<jenkins.version>1.625.3</jenkins.version>
-		<java.level>7</java.level>
+		<jenkins.version>2.361.4</jenkins.version>
 		<jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-		<jackson.version>2.9.9</jackson.version>
-		<httpcomponents.version>4.5.1</httpcomponents.version>
-		<powermock.version>1.6.1</powermock.version>
+		<jackson.version>2.13.4</jackson.version>
+		<httpcomponents.version>4.5.14</httpcomponents.version>
 		<release.skipTests>true</release.skipTests>
 		<findbugs.failOnError>false</findbugs.failOnError>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -64,17 +62,31 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.361.x</artifactId>
+				<version>1757.vf3c66da_b_7492</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>jaxb</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
-			<version>2.1.18</version>
 			<optional>false</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>plain-credentials</artifactId>
-			<version>1.1</version>
 		</dependency>
 
 		<dependency>
@@ -87,16 +99,9 @@
 			<artifactId>httpmime</artifactId>
 			<version>${httpcomponents.version}</version>
 		</dependency>
-
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>jackson2-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/intland/jenkins/api/CodebeamerApiClient.java
+++ b/src/main/java/com/intland/jenkins/api/CodebeamerApiClient.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intland.jenkins.api.dto.*;
 import com.intland.jenkins.coverage.ExecutionContext;
 import jcifs.util.Base64;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.http.Header;
@@ -27,6 +26,7 @@ import org.apache.http.message.BasicHeader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -55,7 +55,7 @@ public class CodebeamerApiClient {
 
 		// initialize rest client
         // http://stackoverflow.com/questions/9539141/httpclient-sends-out-two-requests-when-using-basic-auth
-		final String authHeader = "Basic " + Base64.encode((username + ":" + password).getBytes(Charsets.UTF_8));
+		final String authHeader = "Basic " + Base64.encode((username + ":" + password).getBytes(StandardCharsets.UTF_8));
 
 		HashSet<Header> defaultHeaders = new HashSet<Header>();
 		defaultHeaders.add(new BasicHeader(HttpHeaders.AUTHORIZATION, authHeader));

--- a/src/main/java/com/intland/jenkins/coverage/CodeBeamerCoveragePublisher.java
+++ b/src/main/java/com/intland/jenkins/coverage/CodeBeamerCoveragePublisher.java
@@ -333,7 +333,7 @@ public class CodeBeamerCoveragePublisher extends Publisher {
 		public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project, @QueryParameter String credentialsId) {
 			StandardListBoxModel result = new StandardListBoxModel();
 			if (project == null) {
-				if (!Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+				if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
 					return result.includeCurrentValue(credentialsId);
 				}
 			} else {

--- a/src/main/java/com/intland/jenkins/coverage/CodebeamerCoverageExecutor.java
+++ b/src/main/java/com/intland/jenkins/coverage/CodebeamerCoverageExecutor.java
@@ -211,7 +211,7 @@ public class CodebeamerCoverageExecutor {
 	 */
 	private static void appendJenkinsUrl(CoverageBase coverageData, DirectoryCoverage parentCoverage,
 			ExecutionContext context) {
-		String jenkinsBase = Jenkins.getInstance().getRootUrl();
+		String jenkinsBase = Jenkins.get().getRootUrl();
 		if (StringUtils.isNotBlank(jenkinsBase)) {
 			StringBuilder builder = new StringBuilder();
 			builder.append("<br><br><a class=\"actionLink\" href=\"");

--- a/src/main/java/com/intland/jenkins/coverage/ExecutionContext.java
+++ b/src/main/java/com/intland/jenkins/coverage/ExecutionContext.java
@@ -283,7 +283,7 @@ public class ExecutionContext {
 	}
 
 	public String getBuildResultUrl() {
-		Jenkins jenkins = Jenkins.getInstance();
+		Jenkins jenkins = Jenkins.get();
 		String rootUrl = jenkins.getRootUrl();
 		String jobUrl = build.getUrl();
 		return rootUrl + jobUrl;

--- a/src/main/java/com/intland/jenkins/gcovr/GcovHTMLMarkupBuilder.java
+++ b/src/main/java/com/intland/jenkins/gcovr/GcovHTMLMarkupBuilder.java
@@ -4,16 +4,9 @@ import com.intland.jenkins.coverage.ExecutionContext;
 import com.intland.jenkins.coverage.model.CoverageBase;
 import com.intland.jenkins.coverage.model.CoverageReport;
 import com.intland.jenkins.coverage.model.DirectoryCoverage;
-import hudson.model.Build;
-import hudson.model.Item;
-import hudson.model.Job;
-import hudson.model.TopLevelItem;
-import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * HTML markup builder for a jacoco coverage result


### PR DESCRIPTION
Java 11: update plugin-pom and use api plugins where available. For details, why java 11 -  take a look at the [Jenkins blog](https://www.jenkins.io/blog/2022/12/14/require-java-11/) Also 71% of the plugin users are on this jenkins version or a newer one as can be seen [here](https://stats.jenkins.io/pluginversions/codebeamer-coverage-publisher.html)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
